### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/first-action.yml
+++ b/.github/workflows/first-action.yml
@@ -2,6 +2,8 @@ name: Test Project
 on:
   push:
 
+permissions:
+  contents: read
 jobs:
   test:
     name: Unit Tests


### PR DESCRIPTION
Potential fix for [https://github.com/Everything-Burrito/demo-packages-pkg-a/security/code-scanning/1](https://github.com/Everything-Burrito/demo-packages-pkg-a/security/code-scanning/1)

To fix this problem, we need to set an explicit `permissions:` block in the workflow YAML to limit the permissions granted to the GITHUB_TOKEN in the jobs. The minimal, recommended approach is to add `permissions: contents: read` at the root level of the workflow (above `jobs:`), which will restrict token usage to read-only access to repository contents. Since the steps shown only require access to check out code, run tests, and install Node/NPM dependencies, this permission level is sufficient, and no additional permissions are required. The most direct fix is to insert the following block between lines 4 and 5:

```yaml
permissions:
  contents: read
```

No further imports, definitions, or code changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
